### PR TITLE
Use CupertinoApp

### DIFF
--- a/lib/components/create_session.dart
+++ b/lib/components/create_session.dart
@@ -19,14 +19,13 @@ final HomeController homeController = Get.find();
 class CreateSession extends GetView<CreateSessionController> {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return CupertinoPageScaffold(
       backgroundColor: kColourRightPaneBackground,
-      appBar: AppBar(
+      navigationBar: CupertinoNavigationBar(
         backgroundColor: kColourRightPaneBackground,
-        shadowColor: Colors.transparent,
         leading: CancelCreateSessionButton(),
       ),
-      body: Column(
+      child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
           Column(
@@ -127,20 +126,24 @@ class CreateSession extends GetView<CreateSessionController> {
                       ),
                     ),
                     SettingsTile(
-                        title: Obx(() => ChipsChoice<String>.multiple(
-                              value: controller.volunteerTags.value,
-                              onChanged: (val) {
-                                controller.volunteerTags.value = val;
-                                controller.mockUserListFromDatabase.addAll(val);
-                              },
-                              runSpacing: 20,
-                              choiceItems: C2Choice.listFrom<String, String>(
-                                source: controller.volunteerOptions,
-                                value: (i, v) => v,
-                                label: (i, v) => v,
+                        title: Obx(() => Material(
+                              color: Colors.transparent,
+                              child: ChipsChoice<String>.multiple(
+                                value: controller.volunteerTags.value,
+                                onChanged: (val) {
+                                  controller.volunteerTags.value = val;
+                                  controller.mockUserListFromDatabase
+                                      .addAll(val);
+                                },
+                                runSpacing: 20,
+                                choiceItems: C2Choice.listFrom<String, String>(
+                                  source: controller.volunteerOptions,
+                                  value: (i, v) => v,
+                                  label: (i, v) => v,
+                                ),
+                                choiceActiveStyle: choiceActiveStyle,
+                                choiceStyle: choiceStyle,
                               ),
-                              choiceActiveStyle: choiceActiveStyle,
-                              choiceStyle: choiceStyle,
                             )))
                   ]),
                   SettingsSection(tiles: [

--- a/lib/components/custom_tile_with_choices.dart
+++ b/lib/components/custom_tile_with_choices.dart
@@ -35,16 +35,19 @@ class CustomTileWithChoices extends GetView<CreateSessionController> {
             : Obx(
                 () => Expanded(
                   flex: 4,
-                  child: ChipsChoice<int>.single(
-                    value: tileTag.value,
-                    onChanged: (val) => tileTag.value = val,
-                    choiceItems: C2Choice.listFrom<int, String>(
-                      source: tileOptions,
-                      value: (i, v) => i,
-                      label: (i, v) => v,
+                  child: Material(
+                    color: Colors.transparent,
+                    child: ChipsChoice<int>.single(
+                      value: tileTag.value,
+                      onChanged: (val) => tileTag.value = val,
+                      choiceItems: C2Choice.listFrom<int, String>(
+                        source: tileOptions,
+                        value: (i, v) => i,
+                        label: (i, v) => v,
+                      ),
+                      choiceActiveStyle: choiceActiveStyle,
+                      choiceStyle: choiceStyle,
                     ),
-                    choiceActiveStyle: choiceActiveStyle,
-                    choiceStyle: choiceStyle,
                   ),
                 ),
               ));

--- a/lib/components/date_time_picker.dart
+++ b/lib/components/date_time_picker.dart
@@ -19,80 +19,83 @@ class DateTimePicker extends GetView<CreateSessionController> {
 
   @override
   Widget build(BuildContext context) {
-    return Obx(() => ChipsChoice<int>.single(
-          value: 0,
-          onChanged: (val) {
-            showPopover(
-              barrierColor: Colors.black.withOpacity(0.75),
-              context: context,
-              transitionDuration: const Duration(milliseconds: 150),
-              bodyBuilder: (context) => CupertinoTheme(
-                data: CupertinoThemeData(brightness: Brightness.dark),
-                child: CupertinoDatePicker(
-                  mode: CupertinoDatePickerMode.dateAndTime,
-                  onDateTimeChanged: (dateTime) {
-                    if (isStart) {
-                      controller.startDate.value = dateTime;
-                      controller.startOptions.value = [
-                        formatter.format(dateTime)
-                      ];
+    return Obx(() => Material(
+          color: Colors.transparent,
+          child: ChipsChoice<int>.single(
+            value: 0,
+            onChanged: (val) {
+              showPopover(
+                barrierColor: Colors.black.withOpacity(0.75),
+                context: context,
+                transitionDuration: const Duration(milliseconds: 150),
+                bodyBuilder: (context) => CupertinoTheme(
+                  data: CupertinoThemeData(brightness: Brightness.dark),
+                  child: CupertinoDatePicker(
+                    mode: CupertinoDatePickerMode.dateAndTime,
+                    onDateTimeChanged: (dateTime) {
+                      if (isStart) {
+                        controller.startDate.value = dateTime;
+                        controller.startOptions.value = [
+                          formatter.format(dateTime)
+                        ];
 
-                      controller.endOptions.value = [
-                        formatter.format(
-                            controller.startDate.value.add(Duration(hours: 1)))
-                      ];
-                      controller.endDate.value =
-                          controller.startDate.value.add(Duration(hours: 1));
-                    } else {
-                      controller.endDate.value = dateTime;
-                      controller.endOptions.value = [
-                        formatter.format(dateTime)
-                      ];
-                    }
-                  },
-                  minimumDate: isStart
-                      ? DateTime.now()
-                      : controller.startDate.value.add(Duration(minutes: 1)),
-                  initialDateTime: isStart
-                      ? controller.startDate.value.add(Duration(seconds: 30))
-                      : controller.startDate.value.add(Duration(hours: 1)),
+                        controller.endOptions.value = [
+                          formatter.format(controller.startDate.value
+                              .add(Duration(hours: 1)))
+                        ];
+                        controller.endDate.value =
+                            controller.startDate.value.add(Duration(hours: 1));
+                      } else {
+                        controller.endDate.value = dateTime;
+                        controller.endOptions.value = [
+                          formatter.format(dateTime)
+                        ];
+                      }
+                    },
+                    minimumDate: isStart
+                        ? DateTime.now()
+                        : controller.startDate.value.add(Duration(minutes: 1)),
+                    initialDateTime: isStart
+                        ? controller.startDate.value.add(Duration(seconds: 30))
+                        : controller.startDate.value.add(Duration(hours: 1)),
+                  ),
                 ),
+                direction: PopoverDirection.left,
+                height: 200,
+                width: 350,
+                onPop: () {},
+                arrowHeight: 15,
+                arrowWidth: 30,
+                backgroundColor: kColourRightPaneBackground,
+              );
+            },
+            choiceItems: C2Choice.listFrom<int, String>(
+              source: isStart ? controller.startOptions : controller.endOptions,
+              value: (i, v) => i,
+              label: (i, v) => v,
+            ),
+            choiceActiveStyle: C2ChoiceStyle(
+              backgroundColor: kColourLight,
+              padding: EdgeInsets.all(10.0),
+              color: Colors.white,
+              borderColor: Colors.transparent,
+              labelStyle: TextStyle(
+                fontSize: 16,
               ),
-              direction: PopoverDirection.left,
-              height: 200,
-              width: 350,
-              onPop: () {},
-              arrowHeight: 15,
-              arrowWidth: 30,
-              backgroundColor: kColourRightPaneBackground,
-            );
-          },
-          choiceItems: C2Choice.listFrom<int, String>(
-            source: isStart ? controller.startOptions : controller.endOptions,
-            value: (i, v) => i,
-            label: (i, v) => v,
-          ),
-          choiceActiveStyle: C2ChoiceStyle(
-            backgroundColor: kColourLight,
-            padding: EdgeInsets.all(10.0),
-            color: Colors.white,
-            borderColor: Colors.transparent,
-            labelStyle: TextStyle(
-              fontSize: 16,
+              borderRadius: BorderRadius.all(Radius.circular(8)),
             ),
-            borderRadius: BorderRadius.all(Radius.circular(8)),
-          ),
-          choiceStyle: C2ChoiceStyle(
-            color: Colors.white,
-            labelStyle: TextStyle(
-              fontSize: 16,
+            choiceStyle: C2ChoiceStyle(
+              color: Colors.white,
+              labelStyle: TextStyle(
+                fontSize: 16,
+              ),
+              padding: EdgeInsets.all(10.0),
+              backgroundColor: kColourSidebarTile,
+              borderColor: kColourLight,
+              borderRadius: BorderRadius.all(Radius.circular(5)),
             ),
-            padding: EdgeInsets.all(10.0),
-            backgroundColor: kColourSidebarTile,
-            borderColor: kColourLight,
-            borderRadius: BorderRadius.all(Radius.circular(5)),
+            runSpacing: 20,
           ),
-          runSpacing: 20,
         ));
   }
 }

--- a/lib/components/sidebar.dart
+++ b/lib/components/sidebar.dart
@@ -10,24 +10,21 @@ import 'package:speedwatch/controllers/sidebar_controller.dart';
 class Sidebar extends GetView<SidebarController> {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return CupertinoPageScaffold(
       backgroundColor: kColourSidebarBackground,
-      appBar: AppBar(
+      navigationBar: CupertinoNavigationBar(
         backgroundColor: kColourSidebarBackground,
-        shadowColor: Colors.transparent,
-        actions: <Widget>[
-          CupertinoButton(
-            child: Icon(
-              CupertinoIcons.share_up,
-              color: kColourLight,
-            ),
-            onPressed: () {
-              // do something
-            },
-          )
-        ],
+        trailing: CupertinoButton(
+          child: Icon(
+            CupertinoIcons.share_up,
+            color: kColourLight,
+          ),
+          onPressed: () {
+            // do something
+          },
+        ),
       ),
-      body: Column(
+      child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
           Column(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
@@ -30,7 +31,7 @@ class MyApp extends StatelessWidget {
 
     return GestureDetector(
       onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
-      child: GetMaterialApp(
+      child: GetCupertinoApp(
         title: 'Speed Watch',
         home: HomeView(),
         initialRoute: '/',
@@ -40,6 +41,11 @@ class MyApp extends StatelessWidget {
             page: () => HomeView(),
             transition: Transition.noTransition,
           ),
+        ],
+        localizationsDelegates: [
+          DefaultMaterialLocalizations.delegate,
+          DefaultCupertinoLocalizations.delegate,
+          DefaultWidgetsLocalizations.delegate,
         ],
       ),
     );

--- a/lib/screens/home_view.dart
+++ b/lib/screens/home_view.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:multi_split_view/multi_split_view.dart';
 import 'package:speedwatch/controllers/home_controller.dart';
@@ -8,8 +7,8 @@ import 'package:speedwatch/controllers/home_controller.dart';
 class HomeView extends GetView<HomeController> {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-        body: MultiSplitViewTheme(
+    return CupertinoPageScaffold(
+        child: MultiSplitViewTheme(
       data: MultiSplitViewThemeData(dividerThickness: 1),
       child: Obx(() => MultiSplitView(
             resizable: false,


### PR DESCRIPTION
Replace any usage of Material widgets with their Cupertino equivalents (except for `ElevatedButton.icon`, which doesn’t have a drop-in replacement).
With this change, we won’t need to reinvent the wheel to make `AppBar` look like Cupertino; we can use `CupertinoNavigationBar` instead.